### PR TITLE
Workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,20 +2238,6 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 [[package]]
 name = "uhlc"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7908438f98a5824af02b34c2b31fb369c5764ef835d26df0badbb9897fb28245"
-dependencies = [
- "hex",
- "humantime",
- "lazy_static",
- "log",
- "serde",
- "uuid",
-]
-
-[[package]]
-name = "uhlc"
-version = "0.5.1"
 source = "git+https://github.com/atolab/uhlc-rs.git#956d7944e3e546cf1dc8c1d1c083bfadfef877ae"
 dependencies = [
  "hex",
@@ -2664,7 +2650,7 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 [[package]]
 name = "zenoh"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2688,7 +2674,7 @@ dependencies = [
  "serde_json",
  "socket2",
  "stop-token",
- "uhlc 0.5.1 (git+https://github.com/atolab/uhlc-rs.git)",
+ "uhlc",
  "uuid",
  "vec_map",
  "zenoh-buffers",
@@ -2725,7 +2711,7 @@ dependencies = [
  "rustc_version",
  "serde_json",
  "tempfile",
- "uhlc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uhlc",
  "walkdir",
  "zenoh",
  "zenoh-codec",
@@ -2739,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2747,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -2756,9 +2742,9 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
- "uhlc 0.5.1 (git+https://github.com/atolab/uhlc-rs.git)",
+ "uhlc",
  "zenoh-buffers",
  "zenoh-protocol",
  "zenoh-shm",
@@ -2767,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "zenoh-core",
 ]
@@ -2775,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "flume",
  "json5",
@@ -2793,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2804,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "aes",
  "hmac",
@@ -2817,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2837,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2854,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2877,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2892,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2914,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2932,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2949,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2968,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2980,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "libloading",
  "log",
@@ -2993,12 +2979,12 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "hex",
  "rand",
  "serde",
- "uhlc 0.5.1 (git+https://github.com/atolab/uhlc-rs.git)",
+ "uhlc",
  "uuid",
  "zenoh-buffers",
  "zenoh-core",
@@ -3007,7 +2993,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "bincode",
  "log",
@@ -3020,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3035,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3065,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3093,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "zenoh_backend_traits"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-std = "=1.12.0"
-async-trait = "0.1.57"
+async-trait = "0.1.60"
 dunce = "1.0.2"
 env_logger = "0.10.0"
 git-version = "0.3.5"
@@ -45,7 +45,7 @@ regex = "1.7.0"
 rocksdb = "0.18.0"
 serde_json = "1.0.89"
 tempfile = "3.3.0"
-uhlc = "0.5.1"
+uhlc = { git = "https://github.com/atolab/uhlc-rs.git" } # TODO: Using github source until the no_std update gets released on crates.io
 walkdir = "2.3.2"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = [ "unstable" ] }
 zenoh-codec = {git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }


### PR DESCRIPTION
Related to [this](https://github.com/eclipse-zenoh/zenoh/pull/420), but here there is actually no need for a workspace since there is a single crate. Versions were matched with main repository.