### PR TITLE
Fix Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,21 +25,20 @@ jobs:
     name: Code checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
       - name: Install Rust toolchain
         run: |
           rustup show
           rustup component add rustfmt clippy
+
       - name: Code format check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt --check
+
       - name: Clippy check
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D warnings
+        run: cargo clippy --all-targets --all-features -- --deny warnings
+
       - name: Environment setup
         id: env
         shell: bash
@@ -56,18 +55,18 @@ jobs:
           echo "GITHUB_SHA=${GITHUB_SHA:0:8}"
           GIT_BRANCH=`[[ $GITHUB_REF =~ ^refs/heads/.* ]] && echo ${GITHUB_REF/refs\/heads\//} || true`
           echo "GIT_BRANCH=${GIT_BRANCH}"
-          echo ::set-output name=GIT_BRANCH::"${GIT_BRANCH}"
+          echo "GIT_BRANCH=${GIT_BRANCH}" >> $GITHUB_OUTPUT
           GIT_TAG=`[[ $GITHUB_REF =~ ^refs/tags/.* ]] && echo ${GITHUB_REF/refs\/tags\//} || true`
           echo "GIT_TAG=${GIT_TAG}"
-          echo ::set-output name=GIT_TAG::"${GIT_TAG}"
+          echo "GIT_TAG=${GIT_TAG}" >> $GITHUB_OUTPUT
 
           ZENOH_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
           echo "ZENOH_VERSION=${ZENOH_VERSION}"
-          echo ::set-output name=ZENOH_VERSION::"${ZENOH_VERSION}"
+          echo "ZENOH_VERSION=${ZENOH_VERSION}" >> $GITHUB_OUTPUT
           if [ -n "${GIT_TAG}" ]; then
             IS_RELEASE="true"
             echo "IS_RELEASE=${IS_RELEASE}"
-            echo ::set-output name=IS_RELEASE::"${IS_RELEASE}"
+            echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
             PKG_VERSION=${ZENOH_VERSION}
           elif [ -n "${GIT_BRANCH}" ]; then
             PKG_VERSION=${GIT_BRANCH}-${GITHUB_SHA:0:8}
@@ -75,7 +74,7 @@ jobs:
             PKG_VERSION=${ZENOH_VERSION}-${GITHUB_SHA:0:8}
           fi
           echo "PKG_VERSION=${PKG_VERSION}"
-          echo ::set-output name=PKG_VERSION::"${PKG_VERSION}"
+          echo "PKG_VERSION=${PKG_VERSION}" >> $GITHUB_OUTPUT
     outputs:
       GIT_BRANCH: ${{ steps.env.outputs.GIT_BRANCH }}
       GIT_TAG: ${{ steps.env.outputs.GIT_TAG }}
@@ -91,49 +90,36 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { target: x86_64-unknown-linux-gnu, arch: amd64, os: ubuntu-20.04 }
-          - {
-              target: x86_64-unknown-linux-musl,
-              arch: amd64,
-              os: ubuntu-20.04,
-              use-cross: true,
-            }
-          - {
-              target: arm-unknown-linux-gnueabi,
-              arch: armel,
-              os: ubuntu-20.04,
-              use-cross: true,
-            }
+          - { target: x86_64-unknown-linux-gnu, arch: amd64, os: ubuntu-20.04, build-cmd: "cargo" }
+          - { target: x86_64-unknown-linux-musl, arch: amd64, os: ubuntu-20.04, build-cmd: "cross" }
+          - { target: arm-unknown-linux-gnueabi, arch: armel, os: ubuntu-20.04, build-cmd: "cross" }
           - {
               target: arm-unknown-linux-gnueabihf,
               arch: armhf,
               os: ubuntu-20.04,
-              use-cross: true,
+              build-cmd: "cross",
             }
           - {
               target: armv7-unknown-linux-gnueabihf,
               arch: armhf,
               os: ubuntu-20.04,
-              use-cross: true,
+              build-cmd: "cross",
             }
-          - {
-              target: aarch64-unknown-linux-gnu,
-              arch: arm64,
-              os: ubuntu-20.04,
-              use-cross: true,
-            }
-          - { target: x86_64-apple-darwin, arch: darwin, os: macos-latest }
-          - { target: aarch64-apple-darwin, arch: darwin, os: macos-latest }
-          - { target: x86_64-pc-windows-msvc, arch: win64, os: windows-2019 }
-          - { target: x86_64-pc-windows-gnu, arch: win64, os: windows-2019 }
+          - { target: aarch64-unknown-linux-gnu, arch: arm64, os: ubuntu-20.04, build-cmd: "cross" }
+          - { target: x86_64-apple-darwin, arch: darwin, os: macos-latest, build-cmd: "cargo" }
+          - { target: aarch64-apple-darwin, arch: darwin, os: macos-latest, build-cmd: "cargo" }
+          - { target: x86_64-pc-windows-msvc, arch: win64, os: windows-2019, build-cmd: "cargo" }
+          - { target: x86_64-pc-windows-gnu, arch: win64, os: windows-2019, build-cmd: "cargo" }
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 500 # NOTE: get long history for git-version crate to correctly compute a version
+
       - name: Fetch Git tags # NOTE: workaround for https://github.com/actions/checkout/issues/290
         shell: bash
         run: git fetch --tags --force
+
       - name: Install prerequisites
         shell: bash
         run: |
@@ -156,12 +142,15 @@ jobs:
               ;;
           esac
 
+          cargo install cross --git https://github.com/cross-rs/cross
+
       - name: Windows > Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
         uses: KyleMayes/install-llvm-action@v1
         if: matrix.job.os == 'windows-2019'
         with:
           version: "11.0"
           directory: ${{ runner.temp }}/llvm
+
       - name: Windows > Set LIBCLANG_PATH
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
         if: matrix.job.os == 'windows-2019'
@@ -172,18 +161,11 @@ jobs:
           rustup target add ${{ matrix.job.target }}
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.job.use-cross }}
-          command: build
-          args: --release --target=${{ matrix.job.target }}
+        run: ${{ matrix.job.build-cmd }} build --release --target=${{ matrix.job.target }}
 
       - name: Debian package
         if: contains(matrix.job.target, '-linux-gnu')
-        uses: actions-rs/cargo@v1
-        with:
-          command: deb
-          args: --no-build --target=${{ matrix.job.target }}
+        run: cargo deb --no-build --target=${{ matrix.job.target }}
 
       - name: Packaging
         id: package
@@ -199,7 +181,7 @@ jobs:
               echo "Packaging ${MAIN_PKG_NAME}:"
               zip ${MAIN_PKG_NAME} *.so
               cd -
-              echo ::set-output name=MAIN_PKG_NAME::"${MAIN_PKG_NAME}"
+              echo "MAIN_PKG_NAME=${MAIN_PKG_NAME}" >> $GITHUB_OUTPUT
 
               # check if debian packages has been created and packages them in a single tgz
               if [[ -d target/${TARGET}/debian ]]; then
@@ -207,7 +189,7 @@ jobs:
                 echo "Packaging ${DEBS_PKG_NAME}:"
                 zip ${DEBS_PKG_NAME} *.deb
                 cd -
-                echo ::set-output name=DEBS_PKG_NAME::"${DEBS_PKG_NAME}"
+                echo "DEBS_PKG_NAME=${DEBS_PKG_NAME}" >> $GITHUB_OUTPUT
               fi
               ;;
             *apple*)
@@ -215,19 +197,19 @@ jobs:
               echo "Packaging ${MAIN_PKG_NAME}:"
               zip ${MAIN_PKG_NAME} *.dylib
               cd -
-              echo ::set-output name=MAIN_PKG_NAME::"${MAIN_PKG_NAME}"
+              echo "MAIN_PKG_NAME=${MAIN_PKG_NAME}" >> $GITHUB_OUTPUT
               ;;
             *windows*)
               cd "target/${TARGET}/release/"
               echo "Packaging ${MAIN_PKG_NAME}:"
               7z -y a "${MAIN_PKG_NAME}"  *.dll
               cd -
-              echo ::set-output name=MAIN_PKG_NAME::"${MAIN_PKG_NAME}"
+              echo "MAIN_PKG_NAME=${MAIN_PKG_NAME}" >> $GITHUB_OUTPUT
               ;;
           esac
 
       - name: "Upload packages"
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.job.target }}
           path: |
@@ -241,13 +223,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download result of previous builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: ARTIFACTS
+
       - name: Publish as github release
         uses: softprops/action-gh-release@v1
         with:
           files: ARTIFACTS/*/*.*
+
       - name: Publish to download.eclipse.org/zenoh
         env:
           SSH_TARGET: genie.zenoh@projects-storage.eclipse.org
@@ -271,9 +255,13 @@ jobs:
           scp -o "StrictHostKeyChecking=no" -r * ${SSH_TARGET}:${DOWNLOAD_DIR}/
           echo "---- cleanup identity"
           ssh-add -D
-      - uses: actions/checkout@v2
+
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
       - name: Install Rust toolchain
         run: rustup show
+
       - name: Publish to crates.io
         shell: bash
         run: |


### PR DESCRIPTION
The Release workflow was using the `actions/upload-artifact@master` and `actions/download-artifact@v2`. Recently `actions/upload-artifact@v4` was released with [breaking](https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes) changes which made it incompatible with older releases of `actions/download-artifact`.

I took the chance to remove `actions-rs` actions as they have been archived.