### PR TITLE
fix: Various issues with the Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ on:
         type: boolean
         description: If false (or undefined) the workflow runs in dry-run mode (i.e. with no side-effects)
         required: false
+        default: false
       version:
         type: string
         description: Release number. If undefined, the workflow auto-generates a version using git-describe
@@ -33,14 +34,15 @@ on:
 
 jobs:
   tag:
-    name: Bump and tag crates
-    uses: eclipse-zenoh/ci/.github/workflows/tag-crates.yml@main
+    name: Branch, Bump & tag crates
+    uses: eclipse-zenoh/ci/.github/workflows/branch-bump-tag-crates.yml@main
     with:
       repo: ${{ github.repository }}
-      live-run: ${{ inputs.live-run || false }}
+      live-run: ${{ inputs.live-run }}
       version: ${{ inputs.version }}
-      inter-deps-pattern: ${{ inputs.live-run && 'zenoh.*' || '^$' }}
-      inter-deps-version: ${{ inputs.live-run && inputs.zenoh-version || '' }}
+      bump-deps-pattern: ${{ inputs.live-run && 'zenoh.*' || '^$' }}
+      bump-deps-version: ${{ inputs.live-run && inputs.zenoh-version || '' }}
+      bump-deps-branch: ${{ inputs.live-run && format('release/{0}', inputs.zenoh-version) || '' }}
     secrets: inherit
 
   build-debian:
@@ -62,37 +64,25 @@ jobs:
       version: ${{ needs.tag.outputs.version }}
       branch: ${{ needs.tag.outputs.branch }}
       artifact-patterns: |
-        ^libzenoh_backend_filesystem\.(dylib|so)$
-        ^zenoh_backend_filesystem\.dll$
+        ^libzenoh_backend_fs\.(dylib|so)$
+        ^zenoh_backend_fs\.dll$
     secrets: inherit
 
-  cargo-live-run:
-    if: ${{ inputs.live-run || false }}
-    name: Publish Cargo crates (live-run)
+  cargo:
+    name: Publish Cargo crates
     needs: tag
     uses: eclipse-zenoh/ci/.github/workflows/release-crates-cargo.yml@main
     with:
-      repos: ${{ github.repository }}
-      live-run: true
+      repo: ${{ github.repository }}
+      live-run: ${{ inputs.live-run }}
       branch: ${{ needs.tag.outputs.branch }}
-      inter-deps-pattern: ^$
-    secrets: inherit
-
-  # In dry-run mode, we need to publish eclipse-zenoh/zenoh before this repository,
-  # in which case the version of zenoh dependecies are left as is and thus point to
-  # the main branch of eclipse-zenoh/zenoh
-  cargo-dry-run:
-    if: ${{ !inputs.live-run || true }}
-    name: Publish Cargo crates (dry-run)
-    needs: tag
-    uses: eclipse-zenoh/ci/.github/workflows/release-crates-cargo.yml@main
-    with:
-      repos: |
-        eclipse-zenoh/zenoh
-        ${{ github.repository }}
-      live-run: false
-      branch: ${{ needs.tag.outputs.branch }}
-      inter-deps-pattern: zenoh.*
+      # - In dry-run mode, we need to publish eclipse-zenoh/zenoh before this
+      #   repository, in which case the version of zenoh dependecies are left as
+      #   is and thus point to the main branch of eclipse-zenoh/zenoh.
+      # - In live-run mode, we assume that eclipse-zenoh/zenoh is already
+      #   published as this workflow can't be responsible for publishing it
+      unpublished-deps-patterns: ${{ inputs.live-run && '' || 'zenoh.*' }}
+      unpublished-deps-repos: ${{ inputs.live-run && '' || 'eclipse-zenoh/zenoh' }}
     secrets: inherit
 
   debian:
@@ -101,7 +91,7 @@ jobs:
     uses: eclipse-zenoh/ci/.github/workflows/release-crates-debian.yml@main
     with:
       no-build: true
-      live-run: ${{ inputs.live-run || false }}
+      live-run: ${{ inputs.live-run }}
       version: ${{ needs.tag.outputs.version }}
       repo: ${{ github.repository }}
       branch: ${{ needs.tag.outputs.branch }}
@@ -114,11 +104,11 @@ jobs:
     with:
       no-build: true
       repo: ${{ github.repository }}
-      live-run: ${{ inputs.live-run || false }}
+      live-run: ${{ inputs.live-run }}
       version: ${{ needs.tag.outputs.version }}
       branch: ${{ needs.tag.outputs.branch }}
       artifact-patterns: |
-        ^libzenoh_backend_filesystem\.dylib$
+        ^libzenoh_backend_fs\.dylib$
       formulae: |
         zenoh-backend-filesystem
     secrets: inherit
@@ -129,13 +119,13 @@ jobs:
     uses: eclipse-zenoh/ci/.github/workflows/release-crates-eclipse.yml@main
     with:
       no-build: true
-      live-run: ${{ inputs.live-run || false }}
+      live-run: ${{ inputs.live-run }}
       version: ${{ needs.tag.outputs.version }}
       repo: ${{ github.repository }}
       branch: ${{ needs.tag.outputs.branch }}
       artifact-patterns: |
-        ^libzenoh_backend_filesystem\.(dylib|so)$
-        ^zenoh_backend_filesystem\.dll$
+        ^libzenoh_backend_fs\.(dylib|so)$
+        ^zenoh_backend_fs\.dll$
       name: zenoh-backend-filesystem
     secrets: inherit
 
@@ -145,11 +135,11 @@ jobs:
     uses: eclipse-zenoh/ci/.github/workflows/release-crates-github.yml@main
     with:
       no-build: true
-      live-run: ${{ inputs.live-run || false }}
+      live-run: ${{ inputs.live-run }}
       version: ${{ needs.tag.outputs.version }}
       repo: ${{ github.repository }}
       branch: ${{ needs.tag.outputs.branch }}
       artifact-patterns: |
-        ^libzenoh_backend_filesystem\.(dylib|so)$
-        ^zenoh_backend_filesystem\.dll$
+        ^libzenoh_backend_fs\.(dylib|so)$
+        ^zenoh_backend_fs\.dll$
     secrets: inherit


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/44.

- Always pass in `live-run` input
- Use eclipse-zenoh/zenoh release branch as git source
- Rename `zenoh_backend_filesystem` to `zenoh_backend_fs`in artifact patterns
- Proper handling of unpublished deps in cargo publishing job