### PR TITLE
fix: Add missing `aarch64-unknown-linux-musl` Cross target definition

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -13,3 +13,5 @@ image = "jenoch/rust-cross:armv7-unknown-linux-gnueabihf"
 [target.aarch64-unknown-linux-gnu]
 image = "jenoch/rust-cross:aarch64-unknown-linux-gnu"
 
+[target.aarch64-unknown-linux-musl]
+image = "jenoch/rust-cross:aarch64-unknown-linux-musl"


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/44.