### PR TITLE
fix: Set `installation-test` to false in `release-crates-debian` action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
       version: ${{ needs.tag.outputs.version }}
       repo: ${{ github.repository }}
       branch: ${{ needs.tag.outputs.branch }}
+      installation-test: false
     secrets: inherit
 
   homebrew:


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/44.