### PR TITLE
feat: adding dynamic_plugin feature to enable the declare_plugin macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 stats = ["zenoh/stats"]
+dynamic_plugin = []
+default = ["dynamic_plugin"]
 
 [dependencies]
 async-std = "=1.12.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ pub const PROP_STORAGE_KEEP_MIME: &str = "keep_mime_types";
 pub const ROOT_KEY: &str = "@root";
 
 pub struct FileSystemBackend {}
+
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(FileSystemBackend);
 
 impl Plugin for FileSystemBackend {


### PR DESCRIPTION
Adding a `dynamic_plugin`  feature to feature-gate the `zenoh_plugin_trait::declare_plugin!` by default this feature is enabled.

Disabling it should allow static linking.