### PR TITLE
fix: exclude x86_64-pc-windows-gnu target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
       repo: ${{ github.repository }}
       version: ${{ needs.tag.outputs.version }}
       branch: ${{ needs.tag.outputs.branch }}
+      exclude-builds: '[{ build: { target: "x86_64-pc-windows-gnu", os: "windows-2019" } }]'
       artifact-patterns: |
         ^libzenoh_backend_fs\.(dylib|so)$
         ^zenoh_backend_fs\.dll$


### PR DESCRIPTION
Target currently can't build with latest version of rust-rocksdb.