### PR TITLE
chore: pin librocksdb-sys 1.75 compatible version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,7 @@ home = "0.5.4"
 lazy_static = "1.4.0"
 mime_guess = "2.0.4"
 regex = "1.7.1"
-rocksdb = "=0.23.0"
-librocksdb-sys = "=0.17.1"
+rocksdb = "0.23.0"
 serde_json = "1.0.117"
 tempfile = "3.4.0"
 tokio = { version = "1.35.1", default-features = false } # Default features are disabled due to some crates' requirements
@@ -61,6 +60,7 @@ zenoh = { features = [
 zenoh_backend_traits = { version = "1.5.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-plugin-trait = { version = "1.5.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-ext = { version = "1.5.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-pinned-deps-1-75 = { version = "1.5.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 
 [build-dependencies]
 rustc_version = "0.4.0"


### PR DESCRIPTION
Fix: https://github.com/eclipse-zenoh/ci/actions/runs/16867959615/job/47777567396