### PR TITLE
chore: update bump-deps-pattern for daily runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       version: ${{ inputs.version }}
       branch: ${{ inputs.branch }}
       bump-deps-version: ${{ inputs.zenoh-version }}
-      bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '^$' }}
+      bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '' }}
       bump-deps-branch: ${{ inputs.zenoh-version && format('release/{0}', inputs.zenoh-version) || '' }}
     secrets: inherit
 


### PR DESCRIPTION
Fix: https://github.com/eclipse-zenoh/zenoh-backend-filesystem/actions/runs/17027728091/job/48265320684