### PR TITLE
Updated startup logic to not unecessarily load in all files

### DIFF
--- a/src/files_mgt.rs
+++ b/src/files_mgt.rs
@@ -227,6 +227,28 @@ impl FilesMgr {
         }
     }
 
+    // Like read_file, but skips reading the file's payload — returning only the timestamp.
+    // Used by get_all_entries at startup to avoid loading the entire store into memory.
+    pub(crate) async fn read_timestamp(&self, zfile: &ZFile<'_>) -> ZResult<Option<Timestamp>> {
+        let file = &zfile.fspath;
+        match self.perform_read_timestamp(file).await? {
+            Some(x) => Ok(Some(x)),
+            None => {
+                let file = self.get_conflict_file(file.to_path_buf());
+                self.perform_read_timestamp(&file).await
+            }
+        }
+    }
+
+    async fn perform_read_timestamp(&self, file: &Path) -> ZResult<Option<Timestamp>> {
+        if file.exists() && file.is_file() && (self.follow_links || !self.contains_symlink(file)) {
+            let (_, timestamp) = self.get_encoding_and_timestamp(file).await?;
+            Ok(Some(timestamp))
+        } else {
+            Ok(None)
+        }
+    }
+
     async fn perform_read_from_conflict(
         &self,
         file: PathBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,9 +393,9 @@ impl Storage for FileSystemStorage {
         // Add the root entry if it exists.
         // Root key can't be acuired from `matching_files` call
         // because it's name is specially chosen to be not allowed as key value ("@root")
-        if let Some((_, _, timestamp)) = self
+        if let Some(timestamp) = self
             .files_mgr
-            .read_file(&self.files_mgr.to_zfile(ROOT_KEY))
+            .read_timestamp(&self.files_mgr.to_zfile(ROOT_KEY))
             .await?
         {
             result.push((None, timestamp));
@@ -410,8 +410,8 @@ impl Storage for FileSystemStorage {
         {
             let trimmed_zpath = get_trimmed_keyexpr(zfile.zpath.as_ref());
             let trimmed_zfile = self.files_mgr.to_zfile(trimmed_zpath);
-            match self.files_mgr.read_file(&trimmed_zfile).await {
-                Ok(Some((_, _, timestamp))) => {
+            match self.files_mgr.read_timestamp(&trimmed_zfile).await {
+                Ok(Some(timestamp)) => {
                     let zpath = Some(zfile.zpath.as_ref().try_into().unwrap());
                     result.push((zpath, timestamp));
                 }


### PR DESCRIPTION
Hey folks! Simple fix to remove unnecessary file reads at start up which we think are causing OOMs when our on disk cache gets big enough. See #569 for more details.

I have signed the contributors agreement and linked my github account.

Fixes #569 